### PR TITLE
Add packet reader/writer, slot size & protocol version overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ def write_user_stats(cls, info: UserInfo):
     yield PacketType.BanchoUserStats, stream.data
 ```
 
+Additionally, it's possible to set a certain slot size & protocol version for each version:
+
+```python
+# Set protocol version to 10 for b20120818
+chio.set_protocol_version(10, 20120818)
+
+# Override slot size to 32 for b20160716
+chio.set_slot_size(32, 20160716)
+```
+
 ### Datatypes
 
 Depending on the packet you send or receive, you will need to account for different datatypes.  

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 It was made with the intention of documenting everything about the bancho protocol, and to provide a base for server frameworks, since the packet handling part is most often the annoying part.  
 Having *any* client be able to connect to it is a very sweet addition on top, if you are interested in those as well.
 
+**If you wish to use this library, I would appreciate some credit for my work. Thanks!**
+
 ## Usage
 
 This library requires an installation of python **3.8** or higher.  

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Additionally, it's possible to set a certain slot size & protocol version for ea
 # Set protocol version to 10 for b20120818
 chio.set_protocol_version(10, 20120818)
 
-# Override slot size to 32 for b20160716
-chio.set_slot_size(32, 20160716)
+# Override slot size to 32 for b20160404
+chio.set_slot_size(32, 20160404)
 ```
 
 ### Datatypes

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ encoded = io.write_packet_to_bytes(chio.PacketType.BanchoLoginReply, info.id)
 packet, data = io.read_packet_from_bytes(b"...")
 ```
 
+### Patching
+
+You are able to overwrite specifc packet readers/writers, with the `chio.patch` decorator.
+As an example, to patch the `BanchoUserStats` packet inside of `b20120723`:
+
+```python
+@chio.patch(PacketType.BanchoUserStats, 20120723)
+def write_user_stats(cls, info: UserInfo):
+    stream = MemoryStream()
+    write_u32(stream, cls.convert_user_id(info))
+    stream.write(cls.write_status_update(info.status))
+    write_u64(stream, info.stats.rscore)
+    write_f32(stream, info.stats.accuracy)
+    write_u32(stream, info.stats.playcount)
+    write_u64(stream, info.stats.tscore)
+    write_u32(stream, info.stats.rank)
+    write_u16(stream, info.stats.pp)
+    yield PacketType.BanchoUserStats, stream.data
+```
+
 ### Datatypes
 
 Depending on the packet you send or receive, you will need to account for different datatypes.  

--- a/chio/__init__.py
+++ b/chio/__init__.py
@@ -5,7 +5,7 @@ __version__ = "1.1.3"
 __license__ = "MIT"
 
 from .clients import select_client, set_protocol_version
-from .patching import patch
+from .patching import patch, set_protocol_version, set_slot_size
 from .chio import BanchoIO
 from .io import Stream
 from .constants import *

--- a/chio/__init__.py
+++ b/chio/__init__.py
@@ -5,6 +5,7 @@ __version__ = "1.1.2"
 __license__ = "MIT"
 
 from .clients import select_client, set_protocol_version
+from .patching import patch
 from .chio import BanchoIO
 from .io import Stream
 from .constants import *

--- a/chio/__init__.py
+++ b/chio/__init__.py
@@ -1,7 +1,7 @@
 
 __author__ = "Lekuru"
 __email__ = "contact@lekuru.xyz"
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __license__ = "MIT"
 
 from .clients import select_client, set_protocol_version

--- a/chio/clients/b20130801.py
+++ b/chio/clients/b20130801.py
@@ -22,4 +22,4 @@ class b20130801(b20130604):
             reply = LoginError.InvalidLogin
             yield next(cls.write_announce(InactiveAccountMessage))
 
-        yield next(cls.write_login_reply(reply))
+        yield next(super().write_login_reply(reply))

--- a/chio/patching.py
+++ b/chio/patching.py
@@ -1,0 +1,32 @@
+
+from typing import Callable
+from .clients import ClientDict
+from .constants import *
+
+def patch(packet: PacketType, version: int) -> Callable:
+    """
+    Overwrite a packet handler for a specific protocol version.  
+    For example, to overwrite the `BanchoUserStats` packet for b20120723:
+    ```python
+    @chio.patch(PacketType.BanchoUserStats, 20120723)
+    def write_user_stats(cls, info: UserInfo):
+        stream = MemoryStream()
+        write_u32(stream, cls.convert_user_id(info))
+        stream.write(cls.write_status_update(info.status))
+        write_u64(stream, info.stats.rscore)
+        write_f32(stream, info.stats.accuracy)
+        write_u32(stream, info.stats.playcount)
+        write_u64(stream, info.stats.tscore)
+        write_u32(stream, info.stats.rank)
+        write_u16(stream, info.stats.pp)
+        yield PacketType.BanchoUserStats, stream.data
+    ```
+    """
+    def decorator(func: Callable) -> Callable:
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        
+        client = ClientDict[version]
+        setattr(client, packet.handler_name, wrapper)
+        return wrapper
+    return decorator

--- a/chio/patching.py
+++ b/chio/patching.py
@@ -32,3 +32,13 @@ def patch(packet: PacketType, version: int) -> Callable:
         setattr(client, packet.handler_name, wrapper)
         return wrapper
     return decorator
+
+def set_protocol_version(protocol_version: int, version: int) -> None:
+    """Override the protocol version for a specific client version."""
+    client = ClientDict[version]
+    client.protocol_version = protocol_version
+
+def set_slot_size(slot_size: int, version: int) -> None:
+    """Override the slot size for a specific client version."""
+    client = ClientDict[version]
+    client.slot_size = slot_size

--- a/chio/patching.py
+++ b/chio/patching.py
@@ -1,5 +1,6 @@
 
 from typing import Callable
+from functools import wraps
 from .clients import ClientDict
 from .constants import *
 
@@ -23,9 +24,10 @@ def patch(packet: PacketType, version: int) -> Callable:
     ```
     """
     def decorator(func: Callable) -> Callable:
+        @wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
-        
+
         client = ClientDict[version]
         setattr(client, packet.handler_name, wrapper)
         return wrapper

--- a/chio/types.py
+++ b/chio/types.py
@@ -49,7 +49,6 @@ class UserPresence:
             f"{self.country_name} / {self.city}"
         )
 
-
 @dataclass
 class UserStats:
     rank: int = 0


### PR DESCRIPTION
This pr will allow developers to override packet readers/writers, multiplayer slot sizes and protocol versions for each client version.
Here are some examples from the readme:

```python
# Override user stats writer for b20120723
@chio.patch(PacketType.BanchoUserStats, 20120723)
def write_user_stats(cls, info: UserInfo):
    stream = MemoryStream()
    write_u32(stream, cls.convert_user_id(info))
    stream.write(cls.write_status_update(info.status))
    write_u64(stream, info.stats.rscore)
    write_f32(stream, info.stats.accuracy)
    write_u32(stream, info.stats.playcount)
    write_u64(stream, info.stats.tscore)
    write_u32(stream, info.stats.rank)
    write_u16(stream, info.stats.pp)
    yield PacketType.BanchoUserStats, stream.data

# Set protocol version to 10 for b20120818
chio.set_protocol_version(10, 20120818)

# Override slot size to 32 for b20160404
chio.set_slot_size(32, 20160404)
```