### PR TITLE
Avoid sending Match IDs greater than 0xFF to clients with u8 match implementation

### DIFF
--- a/chio/clients/b1796.py
+++ b/chio/clients/b1796.py
@@ -13,6 +13,14 @@ class b1796(b1788):
     version = 1796
 
     @classmethod
+    def write_match_update(cls, match: Match) -> Iterable[Tuple[PacketType, bytes]]:
+        yield PacketType.BanchoMatchUpdate, cls.write_match(match)
+
+    @classmethod
+    def write_match_new(cls, match: Match) -> Iterable[Tuple[PacketType, bytes]]:
+        yield PacketType.BanchoMatchNew, cls.write_match(match)
+
+    @classmethod
     def write_user_presence(cls, info: UserInfo) -> Iterable[Tuple[PacketType, bytes]]:
         stream = MemoryStream()
         write_u32(stream, cls.convert_user_id(info))

--- a/chio/clients/b298.py
+++ b/chio/clients/b298.py
@@ -13,10 +13,18 @@ class b298(b296):
 
     @classmethod
     def write_match_update(cls, match: Match) -> Iterable[Tuple[PacketType, bytes]]:
+        if match.id > 0xFF:
+            # Match IDs greater than 255 are not supported in this client
+            return []
+
         yield PacketType.BanchoMatchUpdate, cls.write_match(match)
 
     @classmethod
     def write_match_new(cls, match: Match) -> Iterable[Tuple[PacketType, bytes]]:
+        if match.id > 0xFF:
+            # Match IDs greater than 255 are not supported in this client
+            return []
+
         yield PacketType.BanchoMatchNew, cls.write_match(match)
 
     @classmethod


### PR DESCRIPTION
This is a small fail-safe I added to avoid some issues with old clients. It's probably unlikely to happen, but who knows, maybe it could show useful.